### PR TITLE
docs: Compose Multiplatform版へのリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # App Skeleton
 
-A template repository for mobile apps built with Kotlin Multiplatform.
+A template repository for mobile apps built with Kotlin Multiplatform. The UI is native on each
+platform: Jetpack Compose on Android, SwiftUI on iOS.
+
+For a variant that shares the UI across both platforms with Compose Multiplatform, see
+[app-skeleton-cmp](https://github.com/rmakiyama/app-skeleton-cmp).
 
 ## Setup
 


### PR DESCRIPTION
UIをCompose Multiplatformで共有する派生テンプレート [app-skeleton-cmp](https://github.com/rmakiyama/app-skeleton-cmp) を作成したため、READMEから相互に参照できるようにする。

あわせて、このテンプレートのUIがプラットフォームネイティブ（Android: Jetpack Compose / iOS: SwiftUI）である点を冒頭に明記した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)